### PR TITLE
Included support for plone.app.contenttypes Dexterity-based filetypes in jQuery file uploads

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,9 @@ Changelog
 
 - Moved 'Display sort order' button to the right (#5) [jcerjak]
 - Include Products.CMFCore in zcml to get rid of errors when starting the
-instance (Plone >= 4.1) [jcerjak]
+  instance (Plone >= 4.1) [jcerjak]
+- Included support for plone.app.contenttypes Dexterity-based filetypes in
+  jQuery file uploads [sneridagh]
 
 
 1.1b1 (2013-01-24)

--- a/wildcard/foldercontents/configure.zcml
+++ b/wildcard/foldercontents/configure.zcml
@@ -53,5 +53,6 @@
       />
 
   <adapter factory=".factories.ATCTFileFactory" />
+  <adapter factory=".factories.DXFileFactory" />
 
 </configure>

--- a/wildcard/foldercontents/interfaces.py
+++ b/wildcard/foldercontents/interfaces.py
@@ -10,3 +10,8 @@ class ILayer(Interface):
 class IATCTFileFactory(IFileFactory):
     """ adapter factory for ATCT
     """
+
+
+class IDXFileFactory(IFileFactory):
+    """ adapter factory for DX types
+    """


### PR DESCRIPTION
I've started to use wcfc with p.a.contenttypes and realised that it failed as p.a.c get rid of all the AT filetypes. I've added a new factory for DX based filetypes and detection logic to handle both (AT and DX filetypes).
