### PR TITLE
Fix super call to p.a.content.browser.FolderContentsView version for Plone 4.3

### DIFF
--- a/wildcard/foldercontents/views.py
+++ b/wildcard/foldercontents/views.py
@@ -144,7 +144,7 @@ class NewFolderContentsView(FolderContentsView):
             messages = IStatusMessage(self.request)
             messages.add(u"This type of folder does not support ordering",
                 type=u"info")
-        return super(NewFolderContentsView, self).__call__(self)
+        return super(NewFolderContentsView, self).__call__()
 
     def contents_table(self):
         table = NewFolderContentsTable(aq_inner(self.context), self.request)


### PR DESCRIPTION
The Plone 4.3 new version of p.a.content introduces an overwrite of the **call** in browser.FolderContentsView that broke the wfc main view.
