### PR TITLE
Fixes the crash introduced by p.a.content changes in Plone 4.3.4

### DIFF
--- a/wildcard/foldercontents/views.py
+++ b/wildcard/foldercontents/views.py
@@ -115,6 +115,7 @@ class NewFolderContentsTable(FolderContentsTable):
         order = _normalize_form_val(self.request.form, 'sort_order')
         if order:
             self.contentFilter['sort_order'] = 'reverse'
+        self.pagesize = int(self.request.get('pagesize', 20))
         self.items = self.folderitems()
 
         url = context.absolute_url()


### PR DESCRIPTION
Introduced with https://github.com/plone/plone.app.content/commit/70a84714de8a09169fc38a50c3f4a79c4fddddbd.
Only tried with 1.x branch, maybe 2.x are affected too.
